### PR TITLE
Add if condition for checking settings values

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,17 @@ export function activate(context: vscode.ExtensionContext) {
 			const pat = vscode.workspace.getConfiguration('yamlpipelinesvalidator').get('pat');
 			const projectUrl = vscode.workspace.getConfiguration('yamlpipelinesvalidator').get('projecturl');
 			const buildDefinitionId = vscode.workspace.getConfiguration('yamlpipelinesvalidator').get('builddefinitionid');
-			if(isEmptyOrNull(pat as string) || isEmptyOrNull(projectUrl as string) || isEmptyOrNull(buildDefinitionId as string) ){
+			let settingsRequired = false;
+			if(!isEmptyOrNull(pat as string)){
+				settingsRequired = isEmptyOrNull(projectUrl as string) || isEmptyOrNull(buildDefinitionId as string);
+			}
+			if(!isEmptyOrNull(projectUrl as string)){
+				settingsRequired = isEmptyOrNull(pat as string) || isEmptyOrNull(buildDefinitionId as string);
+			}
+			if(!isEmptyOrNull(buildDefinitionId as string)){
+				settingsRequired = isEmptyOrNull(pat as string) || isEmptyOrNull(projectUrl as string);
+			}
+			if(settingsRequired){
 				vscode.window.showErrorMessage("One or more configuration settings have not been set");
 				return;
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,10 @@ export function activate(context: vscode.ExtensionContext) {
 			const pat = vscode.workspace.getConfiguration('yamlpipelinesvalidator').get('pat');
 			const projectUrl = vscode.workspace.getConfiguration('yamlpipelinesvalidator').get('projecturl');
 			const buildDefinitionId = vscode.workspace.getConfiguration('yamlpipelinesvalidator').get('builddefinitionid');
-
+			if(isEmptyOrNull(pat as string) || isEmptyOrNull(projectUrl as string) || isEmptyOrNull(buildDefinitionId as string) ){
+				vscode.window.showErrorMessage("One or more configuration settings have not been set");
+				return;
+			}
 			(async () => {
 				try {
 					await got.post('https://yamlpipelinesvalidator.dev/api/Validation/Validate', {
@@ -60,3 +63,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 // this method is called when your extension is deactivated
 export function deactivate() { }
+
+function isEmptyOrNull(val: string): boolean {
+	return val === null || val === "";
+}


### PR DESCRIPTION
A suggestion PR for short-circuiting the call to API in case settings are not set because I noticed when it is like that the message still pops up indicating valid pipeline. I tried dismissing the first info message about validating but it is not possible in extensions. 